### PR TITLE
OS-6574 packages instrumentation support

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -2,7 +2,7 @@ name: Lint and Test code
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ main, 'feature/*' ]
 
 permissions:
   contents: read

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -2,3 +2,4 @@ tensorflow==2.10.0
 numpy==1.23.3
 torch==2.0.1
 torchvision==0.15.2
+boto3==1.26.160

--- a/examples/s3_instrument.py
+++ b/examples/s3_instrument.py
@@ -1,0 +1,44 @@
+import asyncio
+import json
+import os
+
+import boto3
+
+from optscale_arcee.instrumentation.boto3 import s3
+from optscale_arcee.instrumentation.collector import Collector
+
+access_key_id = 'access_key_id'
+secret_access_key = 'secret_access_key'
+bucket = 'bucket'
+
+s3.instrument()
+
+session = boto3.Session(
+    aws_access_key_id=access_key_id,
+    aws_secret_access_key=secret_access_key
+)
+s3_client = session.client('s3')
+
+s3_client.list_objects_v2(Bucket=bucket, Prefix='')
+
+# sizes to try simple and multipart operations
+for filesize in [1024, 10 * 1024 ** 2]:
+    filename = f'random_file_{filesize}'
+
+    print(f'Creating {filename}')
+    with open(filename, 'wb') as f:
+        f.write(os.urandom(filesize))
+
+    print(f'Uploading {filename} to {bucket}/{filename}')
+    s3_client.upload_file(filename, bucket, filename)
+
+    print(f'Downloading {bucket}/{filename} to {filename}')
+    s3_client.download_file(bucket, filename, filename)
+
+    print(f'Removing {bucket}/{filename}')
+    s3_client.delete_object(Bucket=bucket, Key=filename)
+
+    os.remove(filename)
+
+print('Printing instrumentation result:')
+print(json.dumps(asyncio.run(Collector().get()), indent=2))

--- a/examples/s3_instrument.py
+++ b/examples/s3_instrument.py
@@ -7,17 +7,11 @@ import boto3
 from optscale_arcee.instrumentation.boto3 import s3
 from optscale_arcee.instrumentation.collector import Collector
 
-access_key_id = 'access_key_id'
-secret_access_key = 'secret_access_key'
-bucket = 'bucket'
+bucket = 'amikhalev-bucket-north'
 
 s3.instrument()
 
-session = boto3.Session(
-    aws_access_key_id=access_key_id,
-    aws_secret_access_key=secret_access_key
-)
-s3_client = session.client('s3')
+s3_client = boto3.client('s3')
 
 s3_client.list_objects_v2(Bucket=bucket, Prefix='')
 

--- a/examples/torchvision_demo.py
+++ b/examples/torchvision_demo.py
@@ -1,3 +1,4 @@
+import boto3
 import torch
 from torch import nn
 from torch.utils.data import DataLoader
@@ -6,6 +7,10 @@ from torchvision.transforms import ToTensor
 
 import optscale_arcee as arcee
 
+
+access_key_id = "access_key_id"
+secret_access_key = "secret_access_key"
+bucket = "bucket"
 
 filename = "torchvision.pth"
 
@@ -75,6 +80,7 @@ def test(dataloader, model, loss_fn):
 if __name__ == "__main__":
     # init arcee
     with arcee.init(token="test", model_key="torchvision"):
+        arcee.instrument()
         arcee.tag("project", "torchvision demo")
 
         # Download training data
@@ -128,3 +134,9 @@ if __name__ == "__main__":
         arcee.milestone("Saving model")
         torch.save(model.state_dict(), filename)
         print(f"+Saved PyTorch Model State to {filename}")
+        client = boto3.Session(
+            aws_access_key_id=access_key_id,
+            aws_secret_access_key=secret_access_key
+        ).client("s3")
+        client.upload_file(filename, bucket, filename)
+        print(f"+Uploaded PyTorch Model State to {bucket}/{filename}")

--- a/examples/torchvision_demo.py
+++ b/examples/torchvision_demo.py
@@ -7,11 +7,7 @@ from torchvision.transforms import ToTensor
 
 import optscale_arcee as arcee
 
-
-access_key_id = "access_key_id"
-secret_access_key = "secret_access_key"
 bucket = "bucket"
-
 filename = "torchvision.pth"
 
 batch_size = 64
@@ -134,9 +130,6 @@ if __name__ == "__main__":
         arcee.milestone("Saving model")
         torch.save(model.state_dict(), filename)
         print(f"+Saved PyTorch Model State to {filename}")
-        client = boto3.Session(
-            aws_access_key_id=access_key_id,
-            aws_secret_access_key=secret_access_key
-        ).client("s3")
+        client = boto3.client('s3')
         client.upload_file(filename, bucket, filename)
         print(f"+Uploaded PyTorch Model State to {bucket}/{filename}")

--- a/optscale_arcee/__init__.py
+++ b/optscale_arcee/__init__.py
@@ -1,2 +1,3 @@
 # flake8: noqa: F401
 from .arcee import init, send, tag, milestone, info, finish, error, stage
+from .instrumentation import instrument

--- a/optscale_arcee/arcee.py
+++ b/optscale_arcee/arcee.py
@@ -4,17 +4,7 @@ import threading
 
 from optscale_arcee.sender.sender import Sender
 from optscale_arcee.name_generator import NameGenerator
-
-
-def single(class_):
-    instances = {}
-
-    def get_instance(*args, **kwargs):
-        if class_ not in instances:
-            instances[class_] = class_(*args, **kwargs)
-        return instances[class_]
-
-    return get_instance
+from optscale_arcee.utils import single
 
 
 class Job(threading.Thread):

--- a/optscale_arcee/hw_stat_collector/collector.py
+++ b/optscale_arcee/hw_stat_collector/collector.py
@@ -61,8 +61,8 @@ class Collector:
         cpu_proc = min(
             [
                 round(
-                    process.cpu_percent(interval=proc_interval)
-                    / psutil.cpu_count(),
+                    process.cpu_percent(
+                        interval=proc_interval) / psutil.cpu_count(),
                     2,
                 ),
                 cpu_percent,

--- a/optscale_arcee/hw_stat_collector/collector.py
+++ b/optscale_arcee/hw_stat_collector/collector.py
@@ -61,8 +61,8 @@ class Collector:
         cpu_proc = min(
             [
                 round(
-                    process.cpu_percent(
-                        interval=proc_interval) / psutil.cpu_count(),
+                    process.cpu_percent(interval=proc_interval)
+                    / psutil.cpu_count(),
                     2,
                 ),
                 cpu_percent,

--- a/optscale_arcee/hw_stat_collector/collector.py
+++ b/optscale_arcee/hw_stat_collector/collector.py
@@ -1,11 +1,12 @@
-import asyncio
 import math
 import os
 import concurrent.futures
-from functools import partial, reduce
+from functools import reduce
 
 import GPUtil
 import psutil
+
+from optscale_arcee.utils import run_async
 
 # tune accuracy depending on #cpus
 _MEASURE_TIME = 1 - 1 / (os.cpu_count())
@@ -14,15 +15,6 @@ _TIME_INTERVALS = (_MEASURE_TIME + 0.05, _MEASURE_TIME + 0.01)
 
 class Collector:
     executor = concurrent.futures.ThreadPoolExecutor(max_workers=10)
-
-    @classmethod
-    async def run_async(cls, func, *args, loop=None, executor=None, **kwargs):
-        if loop is None:
-            loop = asyncio.get_event_loop()
-        if executor is None:
-            executor = cls.executor
-        pfunc = partial(func, *args, **kwargs)
-        return await loop.run_in_executor(executor, pfunc)
 
     @staticmethod
     def _gpu_stats():
@@ -121,4 +113,4 @@ class Collector:
 
     @classmethod
     async def collect_stats(cls):
-        return await cls.run_async(cls._collect_stats)
+        return await run_async(cls._collect_stats, executor=cls.executor)

--- a/optscale_arcee/instrumentation/__init__.py
+++ b/optscale_arcee/instrumentation/__init__.py
@@ -1,0 +1,13 @@
+_packages = []
+
+try:
+    from optscale_arcee.instrumentation import boto3
+
+    _packages.append(boto3)
+except ImportError:
+    pass
+
+
+def instrument():
+    for package in _packages:
+        package.instrument()

--- a/optscale_arcee/instrumentation/__init__.py
+++ b/optscale_arcee/instrumentation/__init__.py
@@ -2,8 +2,10 @@ _packages = []
 
 try:
     from optscale_arcee.instrumentation import boto3
+    from optscale_arcee.instrumentation import redshift_connector
 
     _packages.append(boto3)
+    _packages.append(redshift_connector)
 except ImportError:
     pass
 

--- a/optscale_arcee/instrumentation/boto3/__init__.py
+++ b/optscale_arcee/instrumentation/boto3/__init__.py
@@ -1,0 +1,20 @@
+_services = []
+
+try:
+    from optscale_arcee.instrumentation.boto3 import s3
+
+    _services.append(s3)
+except ImportError:
+    pass
+
+try:
+    from optscale_arcee.instrumentation.boto3 import ec2
+
+    _services.append(ec2)
+except ImportError:
+    pass
+
+
+def instrument():
+    for service in _services:
+        service.instrument()

--- a/optscale_arcee/instrumentation/boto3/ec2/__init__.py
+++ b/optscale_arcee/instrumentation/boto3/ec2/__init__.py
@@ -1,7 +1,11 @@
 from optscale_arcee.instrumentation.boto3.stats import (
-    Ec2Stats, register_service)
+    Ec2Stats,
+    register_service,
+)
 from optscale_arcee.instrumentation.boto3.utils import (
-    get_service_name, get_package_name)
+    get_service_name,
+    get_package_name,
+)
 from optscale_arcee.instrumentation.patch import patch, revert_patches
 
 _SERVICE = get_service_name(__file__)
@@ -17,12 +21,18 @@ def instrument():
         pass
     else:
         from optscale_arcee.instrumentation.boto3.wrapper import (
-            create_api_method_wrapper)
+            create_api_method_wrapper,
+        )
 
         # patch basic client methods
-        patch(_PACKAGE, _SERVICE, botocore.client.ClientCreator,
-              '_create_api_method', create_api_method_wrapper,
-              is_service_patch=True)
+        patch(
+            _PACKAGE,
+            _SERVICE,
+            botocore.client.ClientCreator,
+            "_create_api_method",
+            create_api_method_wrapper,
+            is_service_patch=True,
+        )
 
     try:
         import boto3.resources.factory
@@ -30,9 +40,15 @@ def instrument():
         pass
     else:
         from optscale_arcee.instrumentation.boto3.wrapper import (
-            create_action_wrapper)
+            create_action_wrapper,
+        )
 
         # patch resource actions
-        patch(_PACKAGE, _SERVICE, boto3.resources.factory.ResourceFactory,
-              '_create_action', create_action_wrapper,
-              is_service_patch=True)
+        patch(
+            _PACKAGE,
+            _SERVICE,
+            boto3.resources.factory.ResourceFactory,
+            "_create_action",
+            create_action_wrapper,
+            is_service_patch=True,
+        )

--- a/optscale_arcee/instrumentation/boto3/ec2/__init__.py
+++ b/optscale_arcee/instrumentation/boto3/ec2/__init__.py
@@ -1,0 +1,38 @@
+from optscale_arcee.instrumentation.boto3.stats import (
+    Ec2Stats, register_service)
+from optscale_arcee.instrumentation.boto3.utils import (
+    get_service_name, get_package_name)
+from optscale_arcee.instrumentation.patch import patch, revert_patches
+
+_SERVICE = get_service_name(__file__)
+_PACKAGE = get_package_name(__file__)
+
+
+def instrument():
+    register_service(_SERVICE, Ec2Stats)
+    revert_patches(_SERVICE)
+    try:
+        import botocore.client
+    except ImportError:
+        pass
+    else:
+        from optscale_arcee.instrumentation.boto3.wrapper import (
+            create_api_method_wrapper)
+
+        # patch basic client methods
+        patch(_PACKAGE, _SERVICE, botocore.client.ClientCreator,
+              '_create_api_method', create_api_method_wrapper,
+              is_service_patch=True)
+
+    try:
+        import boto3.resources.factory
+    except ImportError:
+        pass
+    else:
+        from optscale_arcee.instrumentation.boto3.wrapper import (
+            create_action_wrapper)
+
+        # patch resource actions
+        patch(_PACKAGE, _SERVICE, boto3.resources.factory.ResourceFactory,
+              '_create_action', create_action_wrapper,
+              is_service_patch=True)

--- a/optscale_arcee/instrumentation/boto3/s3/__init__.py
+++ b/optscale_arcee/instrumentation/boto3/s3/__init__.py
@@ -1,0 +1,100 @@
+from optscale_arcee.instrumentation.boto3.stats import (
+    S3Stats, register_service)
+from optscale_arcee.instrumentation.boto3.utils import (
+    get_service_name, get_package_name)
+from optscale_arcee.instrumentation.patch import patch, revert_patches
+
+_SERVICE = get_service_name(__file__)
+_PACKAGE = get_package_name(__file__)
+
+_S3_TRANSFER_METHODS = [
+    'download_file', 'download_fileobj',
+    'upload_file', 'upload_fileobj',
+    'copy']
+# bucket upload\download methods are wrappers over s3 transfer methods
+_BUCKET_METHODS = ['bucket_load']
+# object upload\download methods are wrappers over s3 transfer methods
+_OBJECT_METHODS = ['object_summary_load']
+_STREAMING_BODY_METHODS = ['read', 'readline', 'readlines']
+
+
+def instrument():
+    register_service(_SERVICE, S3Stats)
+    revert_patches(_SERVICE)
+    try:
+        import botocore.client
+    except ImportError:
+        pass
+    else:
+        from optscale_arcee.instrumentation.boto3.wrapper import (
+            create_api_method_wrapper)
+
+        # patch basic client methods
+        patch(_PACKAGE, _SERVICE, botocore.client.ClientCreator,
+              '_create_api_method', create_api_method_wrapper,
+              is_service_patch=True)
+
+    try:
+        import boto3.resources.factory
+    except ImportError:
+        pass
+    else:
+        from optscale_arcee.instrumentation.boto3.wrapper import (
+            create_action_wrapper)
+
+        # patch resource actions
+        patch(_PACKAGE, _SERVICE, boto3.resources.factory.ResourceFactory,
+              '_create_action', create_action_wrapper,
+              is_service_patch=True)
+
+    try:
+        import boto3.s3.inject
+    except ImportError:
+        pass
+    else:
+        from optscale_arcee.instrumentation.boto3.wrapper import (
+            injected_methods_wrapper)
+
+        # patch client based injected methods
+        for method in _S3_TRANSFER_METHODS + _BUCKET_METHODS + _OBJECT_METHODS:
+            patch(_PACKAGE, _SERVICE, boto3.s3.inject,
+                  method, injected_methods_wrapper,
+                  is_service_patch=True)
+
+    try:
+        import s3transfer.futures
+    except ImportError:
+        pass
+    else:
+        from optscale_arcee.instrumentation.boto3.wrapper import submit_wrapper
+        # patch default ThreadPoolExecutor to be able to map inners calls
+        # to injected methods
+        patch(_PACKAGE, _SERVICE, s3transfer.futures.BoundedExecutor,
+              'submit', submit_wrapper)
+
+    try:
+        import s3transfer.tasks
+    except ImportError:
+        pass
+    else:
+        from optscale_arcee.instrumentation.boto3.wrapper import (
+            task_call_wrapper)
+
+        # patch s3 task __call__ to be able to map inners calls
+        # to injected methods
+        patch(_PACKAGE, _SERVICE, s3transfer.tasks.Task,
+              '__call__', task_call_wrapper)
+
+    try:
+        import botocore.response
+    except ImportError:
+        pass
+    else:
+        from optscale_arcee.instrumentation.boto3.wrapper import (
+            streaming_body_read_wrapper)
+
+        # patch StreamingBody to count downloaded bytes
+        for method in _STREAMING_BODY_METHODS:
+            patch(_PACKAGE, _SERVICE, botocore.response.StreamingBody,
+                  method, streaming_body_read_wrapper,
+                  is_service_patch=True)

--- a/optscale_arcee/instrumentation/boto3/s3/__init__.py
+++ b/optscale_arcee/instrumentation/boto3/s3/__init__.py
@@ -1,21 +1,28 @@
 from optscale_arcee.instrumentation.boto3.stats import (
-    S3Stats, register_service)
+    S3Stats,
+    register_service,
+)
 from optscale_arcee.instrumentation.boto3.utils import (
-    get_service_name, get_package_name)
+    get_service_name,
+    get_package_name,
+)
 from optscale_arcee.instrumentation.patch import patch, revert_patches
 
 _SERVICE = get_service_name(__file__)
 _PACKAGE = get_package_name(__file__)
 
 _S3_TRANSFER_METHODS = [
-    'download_file', 'download_fileobj',
-    'upload_file', 'upload_fileobj',
-    'copy']
+    "download_file",
+    "download_fileobj",
+    "upload_file",
+    "upload_fileobj",
+    "copy",
+]
 # bucket upload\download methods are wrappers over s3 transfer methods
-_BUCKET_METHODS = ['bucket_load']
+_BUCKET_METHODS = ["bucket_load"]
 # object upload\download methods are wrappers over s3 transfer methods
-_OBJECT_METHODS = ['object_summary_load']
-_STREAMING_BODY_METHODS = ['read', 'readline', 'readlines']
+_OBJECT_METHODS = ["object_summary_load"]
+_STREAMING_BODY_METHODS = ["read", "readline", "readlines"]
 
 
 def instrument():
@@ -27,12 +34,18 @@ def instrument():
         pass
     else:
         from optscale_arcee.instrumentation.boto3.wrapper import (
-            create_api_method_wrapper)
+            create_api_method_wrapper,
+        )
 
         # patch basic client methods
-        patch(_PACKAGE, _SERVICE, botocore.client.ClientCreator,
-              '_create_api_method', create_api_method_wrapper,
-              is_service_patch=True)
+        patch(
+            _PACKAGE,
+            _SERVICE,
+            botocore.client.ClientCreator,
+            "_create_api_method",
+            create_api_method_wrapper,
+            is_service_patch=True,
+        )
 
     try:
         import boto3.resources.factory
@@ -40,12 +53,18 @@ def instrument():
         pass
     else:
         from optscale_arcee.instrumentation.boto3.wrapper import (
-            create_action_wrapper)
+            create_action_wrapper,
+        )
 
         # patch resource actions
-        patch(_PACKAGE, _SERVICE, boto3.resources.factory.ResourceFactory,
-              '_create_action', create_action_wrapper,
-              is_service_patch=True)
+        patch(
+            _PACKAGE,
+            _SERVICE,
+            boto3.resources.factory.ResourceFactory,
+            "_create_action",
+            create_action_wrapper,
+            is_service_patch=True,
+        )
 
     try:
         import boto3.s3.inject
@@ -53,13 +72,19 @@ def instrument():
         pass
     else:
         from optscale_arcee.instrumentation.boto3.wrapper import (
-            injected_methods_wrapper)
+            injected_methods_wrapper,
+        )
 
         # patch client based injected methods
         for method in _S3_TRANSFER_METHODS + _BUCKET_METHODS + _OBJECT_METHODS:
-            patch(_PACKAGE, _SERVICE, boto3.s3.inject,
-                  method, injected_methods_wrapper,
-                  is_service_patch=True)
+            patch(
+                _PACKAGE,
+                _SERVICE,
+                boto3.s3.inject,
+                method,
+                injected_methods_wrapper,
+                is_service_patch=True,
+            )
 
     try:
         import s3transfer.futures
@@ -67,10 +92,16 @@ def instrument():
         pass
     else:
         from optscale_arcee.instrumentation.boto3.wrapper import submit_wrapper
+
         # patch default ThreadPoolExecutor to be able to map inners calls
         # to injected methods
-        patch(_PACKAGE, _SERVICE, s3transfer.futures.BoundedExecutor,
-              'submit', submit_wrapper)
+        patch(
+            _PACKAGE,
+            _SERVICE,
+            s3transfer.futures.BoundedExecutor,
+            "submit",
+            submit_wrapper,
+        )
 
     try:
         import s3transfer.tasks
@@ -78,12 +109,18 @@ def instrument():
         pass
     else:
         from optscale_arcee.instrumentation.boto3.wrapper import (
-            task_call_wrapper)
+            task_call_wrapper,
+        )
 
         # patch s3 task __call__ to be able to map inners calls
         # to injected methods
-        patch(_PACKAGE, _SERVICE, s3transfer.tasks.Task,
-              '__call__', task_call_wrapper)
+        patch(
+            _PACKAGE,
+            _SERVICE,
+            s3transfer.tasks.Task,
+            "__call__",
+            task_call_wrapper,
+        )
 
     try:
         import botocore.response
@@ -91,10 +128,16 @@ def instrument():
         pass
     else:
         from optscale_arcee.instrumentation.boto3.wrapper import (
-            streaming_body_read_wrapper)
+            streaming_body_read_wrapper,
+        )
 
         # patch StreamingBody to count downloaded bytes
         for method in _STREAMING_BODY_METHODS:
-            patch(_PACKAGE, _SERVICE, botocore.response.StreamingBody,
-                  method, streaming_body_read_wrapper,
-                  is_service_patch=True)
+            patch(
+                _PACKAGE,
+                _SERVICE,
+                botocore.response.StreamingBody,
+                method,
+                streaming_body_read_wrapper,
+                is_service_patch=True,
+            )

--- a/optscale_arcee/instrumentation/boto3/stats.py
+++ b/optscale_arcee/instrumentation/boto3/stats.py
@@ -1,0 +1,74 @@
+from typing import Type
+
+from optscale_arcee.instrumentation.stats import Stats
+from optscale_arcee.instrumentation.collector import Collector
+
+_STATS_SERVICES = {}
+
+
+def register_service(service_name: str, stats_cls: Type[Stats]):
+    _STATS_SERVICES[service_name] = stats_cls
+
+
+def unregister_service(service_name: str):
+    _STATS_SERVICES.pop(service_name, None)
+
+
+def is_service_registered(service_name: str):
+    return service_name in _STATS_SERVICES
+
+
+class Boto3Stats(Stats):
+    __slots__ = ('method_calls',)
+
+    @property
+    def package(self):
+        return 'boto3'
+
+
+class S3Stats(Boto3Stats):
+    __slots__ = (
+        'bytes_downloaded',
+        'bytes_uploaded',
+        'files_accessed',
+    )
+
+    @property
+    def service(self):
+        return 's3'
+
+
+class Ec2Stats(Boto3Stats):
+    @property
+    def service(self):
+        return 'ec2'
+
+
+def count_uploaded_bytes(service_name: str, bytes_uploaded: int):
+    stats_cls = _STATS_SERVICES.get(service_name)
+    if stats_cls:
+        Collector().add(stats_cls(bytes_uploaded=bytes_uploaded))
+
+
+def count_downloaded_bytes(service_name: str, bytes_downloaded: int):
+    stats_cls = _STATS_SERVICES.get(service_name)
+    if stats_cls:
+        Collector().add(stats_cls(bytes_downloaded=bytes_downloaded))
+
+
+def count_method(service_name: str, method_name: str):
+    stats_cls = _STATS_SERVICES.get(service_name)
+    if stats_cls:
+        Collector().add(stats_cls(method_calls={method_name: 1}))
+
+
+def count_file(service_name: str, bucket: str, filename: str):
+    stats_cls = _STATS_SERVICES.get(service_name)
+    if stats_cls:
+        Collector().add(stats_cls(files_accessed={bucket: {filename}}))
+
+
+def count_files(service_name: str, bucket: str, filenames: list[str]):
+    stats_cls = _STATS_SERVICES.get(service_name)
+    if stats_cls:
+        Collector().add(stats_cls(files_accessed={bucket: {*filenames}}))

--- a/optscale_arcee/instrumentation/boto3/stats.py
+++ b/optscale_arcee/instrumentation/boto3/stats.py
@@ -1,4 +1,4 @@
-from typing import Type
+from typing import Type, List
 
 from optscale_arcee.instrumentation.stats import Stats
 from optscale_arcee.instrumentation.collector import Collector
@@ -68,7 +68,7 @@ def count_file(service_name: str, bucket: str, filename: str):
         Collector().add(stats_cls(files_accessed={bucket: {filename}}))
 
 
-def count_files(service_name: str, bucket: str, filenames: list[str]):
+def count_files(service_name: str, bucket: str, filenames: List[str]):
     stats_cls = _STATS_SERVICES.get(service_name)
     if stats_cls:
         Collector().add(stats_cls(files_accessed={bucket: {*filenames}}))

--- a/optscale_arcee/instrumentation/boto3/stats.py
+++ b/optscale_arcee/instrumentation/boto3/stats.py
@@ -19,29 +19,29 @@ def is_service_registered(service_name: str):
 
 
 class Boto3Stats(Stats):
-    __slots__ = ('method_calls',)
+    __slots__ = ("method_calls",)
 
     @property
     def package(self):
-        return 'boto3'
+        return "boto3"
 
 
 class S3Stats(Boto3Stats):
     __slots__ = (
-        'bytes_downloaded',
-        'bytes_uploaded',
-        'files_accessed',
+        "bytes_downloaded",
+        "bytes_uploaded",
+        "files_accessed",
     )
 
     @property
     def service(self):
-        return 's3'
+        return "s3"
 
 
 class Ec2Stats(Boto3Stats):
     @property
     def service(self):
-        return 'ec2'
+        return "ec2"
 
 
 def count_uploaded_bytes(service_name: str, bytes_uploaded: int):

--- a/optscale_arcee/instrumentation/boto3/utils.py
+++ b/optscale_arcee/instrumentation/boto3/utils.py
@@ -1,0 +1,56 @@
+import os
+import threading
+from contextlib import contextmanager
+
+from optscale_arcee.utils import single
+
+
+def get_service_name(path: str) -> str:
+    return os.path.basename(os.path.dirname(path)).lower()
+
+
+def get_package_name(path: str) -> str:
+    return os.path.basename(os.path.dirname(
+        os.path.dirname(path))).lower()
+
+
+def list_services() -> list[str]:
+    services = []
+    for a in os.listdir(os.path.dirname(__file__)):
+        if os.path.isdir(a) and not a.startswith('_'):
+            services.append(a)
+    return services
+
+
+@single
+class ThreadedMethodsTracker:
+    """
+    Track what method in what thread is executed
+    """
+    TID_METHOD_MAP = {}
+    TID_COUNTER_MAP = {}
+
+    @contextmanager
+    def manage_method(self, method: str):
+        tid = threading.current_thread().native_id
+        self._add(tid, method)
+        try:
+            yield
+        finally:
+            self._delete(tid)
+
+    def _add(self, tid: int, method: str):
+        if tid not in self.__class__.TID_COUNTER_MAP:
+            self.__class__.TID_COUNTER_MAP[tid] = 0
+            self.__class__.TID_METHOD_MAP[tid] = method
+        self.__class__.TID_COUNTER_MAP[tid] += 1
+
+    def _delete(self, tid: int):
+        self.__class__.TID_COUNTER_MAP[tid] -= 1
+        if self.__class__.TID_COUNTER_MAP[tid] == 0:
+            self.__class__.TID_COUNTER_MAP.pop(tid)
+            self.__class__.TID_METHOD_MAP.pop(tid)
+
+    def get(self) -> str:
+        tid = threading.current_thread().native_id
+        return self.__class__.TID_METHOD_MAP.get(tid)

--- a/optscale_arcee/instrumentation/boto3/utils.py
+++ b/optscale_arcee/instrumentation/boto3/utils.py
@@ -11,14 +11,13 @@ def get_service_name(path: str) -> str:
 
 
 def get_package_name(path: str) -> str:
-    return os.path.basename(os.path.dirname(
-        os.path.dirname(path))).lower()
+    return os.path.basename(os.path.dirname(os.path.dirname(path))).lower()
 
 
 def list_services() -> List[str]:
     services = []
     for a in os.listdir(os.path.dirname(__file__)):
-        if os.path.isdir(a) and not a.startswith('_'):
+        if os.path.isdir(a) and not a.startswith("_"):
             services.append(a)
     return services
 
@@ -28,6 +27,7 @@ class ThreadedMethodsTracker:
     """
     Track what method in what thread is executed
     """
+
     TID_METHOD_MAP = {}
     TID_COUNTER_MAP = {}
 

--- a/optscale_arcee/instrumentation/boto3/utils.py
+++ b/optscale_arcee/instrumentation/boto3/utils.py
@@ -1,6 +1,7 @@
 import os
 import threading
 from contextlib import contextmanager
+from typing import List
 
 from optscale_arcee.utils import single
 
@@ -14,7 +15,7 @@ def get_package_name(path: str) -> str:
         os.path.dirname(path))).lower()
 
 
-def list_services() -> list[str]:
+def list_services() -> List[str]:
     services = []
     for a in os.listdir(os.path.dirname(__file__)):
         if os.path.isdir(a) and not a.startswith('_'):

--- a/optscale_arcee/instrumentation/boto3/wrapper.py
+++ b/optscale_arcee/instrumentation/boto3/wrapper.py
@@ -1,0 +1,236 @@
+import inspect
+import logging
+import os
+
+from optscale_arcee.instrumentation.boto3.stats import (
+    count_downloaded_bytes, count_uploaded_bytes, count_file, count_method,
+    is_service_registered, count_files)
+from optscale_arcee.instrumentation.boto3.utils import (
+    ThreadedMethodsTracker, get_service_name)
+from optscale_arcee.instrumentation.patch import update_wrapper
+
+
+CALLER_FUNCTION_NAME = f'_{get_service_name(__file__)}_caller_function'
+LOG = logging.getLogger(__name__)
+
+
+def map_values_to_params(func, *args, **kwargs) -> dict:
+    signature = inspect.signature(func)
+    params = signature.bind(*args, **kwargs)
+    # TODO: set defaults also if not passed
+    return params.arguments
+
+
+def is_threaded_method() -> bool:
+    # inner method may be called in separate thread of task executor
+    return ThreadedMethodsTracker().get() is not None
+
+
+def is_rewrapped_method(distance: int = 1) -> bool:
+    # distance between current func stack and tracking wrapper
+    # default value is set for the following case:
+    # 0 - this func
+    # 1 - rewrapped candidate frame
+    res = False
+    stack = inspect.stack()
+    if len(stack) > distance + 1:
+        wrapper_frame = stack[distance]
+        upper_frames = stack[distance + 1:]
+        # calling wrapped method inside another wrapped method
+        res |= any(map(lambda x:
+                       x.filename == wrapper_frame.filename and
+                       x.function == wrapper_frame.function,
+                       upper_frames))
+    return res
+
+
+def upload_part(
+        service: str, params: dict, is_threaded: bool, is_rewrapped: bool
+):
+    # always count uploaded bytes
+    count_uploaded_bytes(service, len(params['kwargs'].get('Body', {})))
+
+
+def delete_object(
+        service: str, params: dict, is_threaded: bool, is_rewrapped: bool
+):
+    if is_threaded or is_rewrapped:
+        return
+    count_file(service, params['kwargs']['Bucket'], params['kwargs']['Key'])
+
+
+def delete_objects(
+        service: str, params: dict, is_threaded: bool, is_rewrapped: bool
+):
+    if is_threaded or is_rewrapped:
+        return
+    filenames = list(map(
+        lambda x: x['Key'], params['kwargs']['Delete']['Objects']))
+    if 'Bucket' not in params['kwargs']:
+        bucket = params['self'].name
+    else:
+        bucket = params['kwargs']['Bucket']
+    count_files(service, bucket, filenames)
+
+
+def get(
+        service: str, params: dict, is_threaded: bool, is_rewrapped: bool
+):
+    if is_threaded or is_rewrapped:
+        return
+    # Bucket and key are properties of Object (s3.Object)
+    count_file(service, params['self'].bucket_name, params['self'].key)
+
+
+def delete(
+        service: str, params: dict, is_threaded: bool, is_rewrapped: bool
+):
+    if is_threaded or is_rewrapped:
+        return
+    # Bucket and key are properties of Object (s3.Object)
+    count_file(service, params['self'].bucket_name, params['self'].key)
+
+
+def copy_object(
+        service: str, params: dict, is_threaded: bool, is_rewrapped: bool
+):
+    if is_threaded or is_rewrapped:
+        return
+    # all "simple" methods params are kwargs
+    count_file(service, params['kwargs']['CopySource']['Bucket'],
+               params['kwargs']['CopySource']['Key'])
+    # 'Key' on download_fileobj, upload_file, upload_fileobj
+    count_file(service, params['kwargs']['Bucket'],
+               params['kwargs']['Key'])
+
+
+def put_object(
+        service: str, params: dict, is_threaded: bool, is_rewrapped: bool
+):
+    if not is_threaded and not is_rewrapped:
+        # Bucket may be property of Bucket object (s3.Bucket)
+        if 'Bucket' not in params['kwargs']:
+            bucket = params['self'].name
+        else:
+            bucket = params['kwargs']['Bucket']
+        # count file if method called directly
+        count_file(service, bucket, params['kwargs']['Key'])
+    if not is_rewrapped:
+        # count in direct and threaded calls (part of complex method) cases
+        try:
+            count_uploaded_bytes(
+                service, len(params['kwargs'].get('Body', '')))
+        except Exception as ex:  # typically TypeError
+            LOG.debug('%s - %s', type(ex), str(ex))
+            if hasattr(params['kwargs'].get('Body', ''), 'name'):
+                count_uploaded_bytes(
+                    service, os.stat(params['kwargs']['Body'].name).st_size)
+
+
+HANDLER_FUNCTIONS = {
+    'upload_part': upload_part,
+    'delete_object': delete_object,
+    'delete_objects': delete_objects,
+    'get': get,
+    'delete': delete,
+    'copy_object': copy_object,
+    'put_object': put_object
+}
+
+
+def method_wrapper(service, original):
+    def _method(*args, **kwargs):
+        res = original(*args, **kwargs)
+        is_threaded = is_threaded_method()
+        is_rewrapped = is_rewrapped_method()
+        if not is_threaded and not is_rewrapped:
+            count_method(service, original.__name__)
+        handler_func = HANDLER_FUNCTIONS.get(original.__name__)
+        if handler_func:
+            params = map_values_to_params(original, *args, **kwargs)
+            handler_func(service, params, is_threaded, is_rewrapped)
+        return res
+    return _method
+
+
+def create_action_wrapper(service, original, *args, **kwargs):
+    action = original(*args, **kwargs)
+    service_context = map_values_to_params(
+        original, *args, **kwargs).get('service_context')
+    if not service_context:
+        return action
+    resource_service = getattr(service_context, 'service_name', None)
+    if not is_service_registered(resource_service):
+        return action
+    if resource_service != service:
+        return action
+    wrapped_action = method_wrapper(service, action)
+    return update_wrapper(wrapped_action, action)
+
+
+def create_api_method_wrapper(service, original, *args, **kwargs):
+    api_method = original(*args, **kwargs)
+    service_model = map_values_to_params(
+        original, *args, **kwargs).get('service_model')
+    if not service_model:
+        return api_method
+    client_service = getattr(service_model, 'service_name', None)
+    if not is_service_registered(client_service):
+        return api_method
+    if client_service != service:
+        return api_method
+    wrapped_api_method = method_wrapper(service, api_method)
+    return update_wrapper(wrapped_api_method, api_method)
+
+
+def injected_methods_wrapper(service, original, *args, **kwargs):
+    res = original(*args, **kwargs)
+    # ignore specific injected methods which call list_buckets and head_object
+    if original.__name__ not in ['bucket_load', 'object_summary_load']:
+        count_method(service, original.__name__)
+    params = map_values_to_params(original, *args, **kwargs)
+    if 'Key' in params and 'Bucket' in params:
+        if original.__name__ == 'copy':
+            # on copy handle source and target
+            count_file(service, params['CopySource']['Bucket'],
+                       params['CopySource']['Key'])
+        count_file(service, params['Bucket'], params['Key'])
+    return res
+
+
+def submit_wrapper(original, submit_self, task_object, /, *args, **kwargs):
+    # if task is submitted from submitted task
+    caller_function = ThreadedMethodsTracker().get()
+    if caller_function is None:
+        # if task is submitted from main thread
+        # typically is submitted from base wrapped method (injected)
+        stack = inspect.stack()
+        caller_function = None
+        for idx, frame in enumerate(stack):
+            # if wrapped then call already counted
+            if frame.function == 'injected_methods_wrapper':
+                caller_function = stack[idx - 1].function
+                break
+    # setting attribute to pass caller function name
+    # inside task __call__ method
+    if caller_function:
+        setattr(task_object, CALLER_FUNCTION_NAME, caller_function)
+    future = original(submit_self, task_object, *args, **kwargs)
+    return future
+
+
+def task_call_wrapper(original, *args, **kwargs):
+    cls_self = args[0]
+    if hasattr(cls_self, CALLER_FUNCTION_NAME):
+        with ThreadedMethodsTracker().manage_method(
+                getattr(cls_self, CALLER_FUNCTION_NAME)):
+            res = original(*args, **kwargs)
+    else:
+        res = original(*args, **kwargs)
+    return res
+
+
+def streaming_body_read_wrapper(service, original, *args, **kwargs):
+    res = original(*args, **kwargs)
+    count_downloaded_bytes(service, len(res))
+    return res

--- a/optscale_arcee/instrumentation/boto3/wrapper.py
+++ b/optscale_arcee/instrumentation/boto3/wrapper.py
@@ -198,7 +198,7 @@ def injected_methods_wrapper(service, original, *args, **kwargs):
     return res
 
 
-def submit_wrapper(original, submit_self, task_object, /, *args, **kwargs):
+def submit_wrapper(original, *args, **kwargs):
     # if task is submitted from submitted task
     caller_function = ThreadedMethodsTracker().get()
     if caller_function is None:
@@ -213,9 +213,10 @@ def submit_wrapper(original, submit_self, task_object, /, *args, **kwargs):
                 break
     # setting attribute to pass caller function name
     # inside task __call__ method
+    params = map_values_to_params(original, *args, **kwargs)
     if caller_function:
-        setattr(task_object, CALLER_FUNCTION_NAME, caller_function)
-    future = original(submit_self, task_object, *args, **kwargs)
+        setattr(params['task'], CALLER_FUNCTION_NAME, caller_function)
+    future = original(**params)
     return future
 
 

--- a/optscale_arcee/instrumentation/boto3/wrapper.py
+++ b/optscale_arcee/instrumentation/boto3/wrapper.py
@@ -44,13 +44,10 @@ def is_rewrapped_method(distance: int = 1) -> bool:
         wrapper_frame = stack[distance]
         upper_frames = stack[distance + 1:]
         # calling wrapped method inside another wrapped method
-        res |= any(
-            map(
-                lambda x: x.filename == wrapper_frame.filename
-                and x.function == wrapper_frame.function,
-                upper_frames,
-            )
-        )
+        res |= any(map(lambda x:
+                       x.filename == wrapper_frame.filename and
+                       x.function == wrapper_frame.function,
+                       upper_frames))
     return res
 
 

--- a/optscale_arcee/instrumentation/boto3_stats.md
+++ b/optscale_arcee/instrumentation/boto3_stats.md
@@ -1,0 +1,15 @@
+Services stats
+====
+
+### S3
+| Parameter        | Description                                                                                           |
+|------------------|-------------------------------------------------------------------------------------------------------|
+| method_calls     | The amount of methods calls                                                                           |
+| bytes_downloaded | The amount of downloaded bytes                                                                        |
+| bytes_uploaded   | The amount of uploaded bytes                                                                          |
+| files_accessed   | List of files that have been accessed. Files are counted on download, upload, copy, delete operations |
+
+### EC2
+| Parameter    | Description                 | 
+|--------------|-----------------------------|
+| method_calls | The amount of methods calls |

--- a/optscale_arcee/instrumentation/collector.py
+++ b/optscale_arcee/instrumentation/collector.py
@@ -1,0 +1,44 @@
+import json
+from concurrent.futures import ThreadPoolExecutor
+from queue import Queue
+from typing import Type
+
+from optscale_arcee.instrumentation.stats import Stats
+from optscale_arcee.utils import single, run_async
+
+
+class Encoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, set):
+            return list(obj)
+        return json.JSONEncoder.default(self, obj)
+
+
+@single
+class Collector:
+    _queue = Queue()
+    _executor = ThreadPoolExecutor(max_workers=5)
+
+    def add(self, stats: Type[Stats]):
+        self._queue.put_nowait(stats)
+
+    def _get(self) -> dict:
+        stats_map = {}
+        while not self._queue.empty():
+            stats = self._queue.get_nowait()
+            if type(stats) not in stats_map:
+                stats_map[type(stats)] = stats
+            else:
+                stats_map[type(stats)] += stats
+        res = {}
+        for stats in stats_map.values():
+            if stats.package not in res:
+                res[stats.package] = {}
+            if stats.service:
+                res[stats.package][stats.service] = stats.to_dict()
+            else:
+                res[stats.package] = stats.to_dict()
+        return json.loads(json.dumps(res, cls=Encoder))
+
+    async def get(self) -> dict:
+        return await run_async(self._get, executor=self._executor)

--- a/optscale_arcee/instrumentation/patch.py
+++ b/optscale_arcee/instrumentation/patch.py
@@ -1,0 +1,80 @@
+import functools
+import inspect
+import logging
+from collections import defaultdict
+from typing import Callable
+
+import gorilla
+
+APPLIED_PATCHES = defaultdict(set)
+LOG = logging.getLogger(__name__)
+
+
+class PatcherSettings(gorilla.Settings):
+    def __hash__(self):
+        return hash(tuple(sorted(iter(self.__dict__.items()))))
+
+
+class GorillaPatch(gorilla.Patch):
+    def __hash__(self):
+        # patches of same objects will be different because of wrappers
+        # objects nature. Will have to exclude 'obj' attr from hash calculation
+        # to get rid of this
+        return hash(tuple(sorted(iter(self.__dict__.items()))))
+
+    def __eq__(self, other):
+        if isinstance(other, type(self)):
+            return self.__hash__() == other.__hash__()
+
+        return NotImplemented
+
+
+def update_wrapper(wrapper, wrapped):
+    updated_wrapper = functools.update_wrapper(wrapper, wrapped)
+    try:
+        # TODO: check if required
+        updated_wrapper.__signature__ = inspect.signature(wrapped)
+    except Exception:
+        LOG.error("Failed to set %s signature to wrapper", wrapper, wrapped)
+    return updated_wrapper
+
+
+def _create_patch(
+        destination: object, name: str, patch_obj: object
+) -> GorillaPatch:
+    gorilla_patch = GorillaPatch(
+        destination, name,
+        patch_obj,
+        settings=PatcherSettings(allow_hit=True, store_hit=True)
+    )
+    return gorilla_patch
+
+
+def _apply_patch(component: str, gorilla_patch: GorillaPatch):
+    gorilla.apply(gorilla_patch)
+    APPLIED_PATCHES[component].add(gorilla_patch)
+
+
+def patch(
+        package: str, service: str, destination: object, name: str,
+        patch_func: Callable, is_package_patch=False, is_service_patch=False):
+    original_func = gorilla.get_attribute(destination, name)
+    if is_package_patch:
+        def wrapper(*args, **kwargs):
+            return patch_func(package, original_func, *args, **kwargs)
+    elif is_service_patch:
+        def wrapper(*args, **kwargs):
+            return patch_func(service, original_func, *args, **kwargs)
+    else:
+        def wrapper(*args, **kwargs):
+            return patch_func(original_func, *args, **kwargs)
+
+    wrapped_func = update_wrapper(wrapper, original_func)
+
+    gorilla_patch = _create_patch(destination, name, wrapped_func)
+    _apply_patch(service or package, gorilla_patch)
+
+
+def revert_patches(component: str):
+    for gorilla_patch in APPLIED_PATCHES.pop(component, []):
+        gorilla.revert(gorilla_patch)

--- a/optscale_arcee/instrumentation/patch.py
+++ b/optscale_arcee/instrumentation/patch.py
@@ -2,7 +2,7 @@ import functools
 import inspect
 import logging
 from collections import defaultdict
-from typing import Callable
+from typing import Callable, Optional
 
 import gorilla
 
@@ -56,7 +56,7 @@ def _apply_patch(component: str, gorilla_patch: GorillaPatch):
 
 
 def patch(
-        package: str, service: str, destination: object, name: str,
+        package: str, service: Optional[str], destination: object, name: str,
         patch_func: Callable, is_package_patch=False, is_service_patch=False):
     original_func = gorilla.get_attribute(destination, name)
     if is_package_patch:

--- a/optscale_arcee/instrumentation/patch.py
+++ b/optscale_arcee/instrumentation/patch.py
@@ -40,12 +40,13 @@ def update_wrapper(wrapper, wrapped):
 
 
 def _create_patch(
-        destination: object, name: str, patch_obj: object
+    destination: object, name: str, patch_obj: object
 ) -> GorillaPatch:
     gorilla_patch = GorillaPatch(
-        destination, name,
+        destination,
+        name,
         patch_obj,
-        settings=PatcherSettings(allow_hit=True, store_hit=True)
+        settings=PatcherSettings(allow_hit=True, store_hit=True),
     )
     return gorilla_patch
 
@@ -56,16 +57,27 @@ def _apply_patch(component: str, gorilla_patch: GorillaPatch):
 
 
 def patch(
-        package: str, service: Optional[str], destination: object, name: str,
-        patch_func: Callable, is_package_patch=False, is_service_patch=False):
+    package: str,
+    service: Optional[str],
+    destination: object,
+    name: str,
+    patch_func: Callable,
+    is_package_patch=False,
+    is_service_patch=False,
+):
     original_func = gorilla.get_attribute(destination, name)
     if is_package_patch:
+
         def wrapper(*args, **kwargs):
             return patch_func(package, original_func, *args, **kwargs)
+
     elif is_service_patch:
+
         def wrapper(*args, **kwargs):
             return patch_func(service, original_func, *args, **kwargs)
+
     else:
+
         def wrapper(*args, **kwargs):
             return patch_func(original_func, *args, **kwargs)
 

--- a/optscale_arcee/instrumentation/redshift_connector/__init__.py
+++ b/optscale_arcee/instrumentation/redshift_connector/__init__.py
@@ -1,7 +1,4 @@
 from optscale_arcee.instrumentation.patch import patch, revert_patches
-from optscale_arcee.instrumentation.redshift_connector.stats import (
-    RedshiftConnectorStats,
-)
 from optscale_arcee.instrumentation.utils import get_package_name
 
 _PACKAGE = get_package_name(__file__)

--- a/optscale_arcee/instrumentation/redshift_connector/__init__.py
+++ b/optscale_arcee/instrumentation/redshift_connector/__init__.py
@@ -1,6 +1,7 @@
 from optscale_arcee.instrumentation.patch import patch, revert_patches
 from optscale_arcee.instrumentation.redshift_connector.stats import (
-    RedshiftConnectorStats)
+    RedshiftConnectorStats,
+)
 from optscale_arcee.instrumentation.utils import get_package_name
 
 _PACKAGE = get_package_name(__file__)
@@ -14,7 +15,13 @@ def instrument():
         pass
     else:
         from optscale_arcee.instrumentation.redshift_connector.wrapper import (
-            close_wrapper)
+            close_wrapper,
+        )
 
-        patch(_PACKAGE, None, redshift_connector.core.Connection,
-              'close', close_wrapper)
+        patch(
+            _PACKAGE,
+            None,
+            redshift_connector.core.Connection,
+            "close",
+            close_wrapper,
+        )

--- a/optscale_arcee/instrumentation/redshift_connector/__init__.py
+++ b/optscale_arcee/instrumentation/redshift_connector/__init__.py
@@ -1,0 +1,20 @@
+from optscale_arcee.instrumentation.patch import patch, revert_patches
+from optscale_arcee.instrumentation.redshift_connector.stats import (
+    RedshiftConnectorStats)
+from optscale_arcee.instrumentation.utils import get_package_name
+
+_PACKAGE = get_package_name(__file__)
+
+
+def instrument():
+    revert_patches(_PACKAGE)
+    try:
+        import redshift_connector
+    except ImportError:
+        pass
+    else:
+        from optscale_arcee.instrumentation.redshift_connector.wrapper import (
+            close_wrapper)
+
+        patch(_PACKAGE, None, redshift_connector.core.Connection,
+              'close', close_wrapper)

--- a/optscale_arcee/instrumentation/redshift_connector/stats.py
+++ b/optscale_arcee/instrumentation/redshift_connector/stats.py
@@ -1,0 +1,16 @@
+from typing import List
+
+from optscale_arcee.instrumentation.collector import Collector
+from optscale_arcee.instrumentation.stats import Stats
+
+
+class RedshiftConnectorStats(Stats):
+    __slots__ = ('queries',)
+
+    @property
+    def package(self):
+        return 'redshift_connector'
+
+
+def count_queries(queries: List[dict]):
+    Collector().add(RedshiftConnectorStats(queries=queries))

--- a/optscale_arcee/instrumentation/redshift_connector/stats.py
+++ b/optscale_arcee/instrumentation/redshift_connector/stats.py
@@ -5,11 +5,11 @@ from optscale_arcee.instrumentation.stats import Stats
 
 
 class RedshiftConnectorStats(Stats):
-    __slots__ = ('queries',)
+    __slots__ = ("queries",)
 
     @property
     def package(self):
-        return 'redshift_connector'
+        return "redshift_connector"
 
 
 def count_queries(queries: List[dict]):

--- a/optscale_arcee/instrumentation/redshift_connector/wrapper.py
+++ b/optscale_arcee/instrumentation/redshift_connector/wrapper.py
@@ -1,0 +1,79 @@
+from typing import List
+
+from optscale_arcee.instrumentation.redshift_connector.stats import (
+    count_queries)
+
+SERVICE_PREFIX = '/* requestor: Optscale */'
+
+
+def add_query_prefix(query_text: str) -> str:
+    # add specific prefix to mark our service queries
+    return f'{SERVICE_PREFIX} {query_text}'
+
+
+def get_connection_info(cursor) -> tuple[int, int, str]:
+    connection_info_query = """
+    select 
+      pg_backend_pid() as session_id, 
+      current_user_id as user_id, 
+      current_database() as database
+    """
+    cursor.execute(add_query_prefix(connection_info_query))
+    result = cursor.fetchone()
+    session_id, user_id, database = result
+    return session_id, user_id, database
+
+
+def get_queries_info(
+        cursor, database: str, user_id: int, session_id: int
+) -> List[dict]:
+    # collect executed queries info in current session scope
+    # excluding service queries
+    query_string = """
+    select 
+      database_name, 
+      start_time, 
+      end_time, 
+      trim(status) as status,  
+      trim(query_text) as query, 
+      elapsed_time, 
+      returned_rows, 
+      returned_bytes 
+    from 
+      sys_query_history 
+    where 
+      session_id = {session_id} 
+      and database_name = '{database}' 
+      and user_id = {user_id} 
+      and substring(query, 1, {prefix_len}) != '{prefix}'
+    order by 
+      start_time asc
+    """.format(
+        database=database, session_id=session_id, user_id=user_id,
+        prefix_len=len(SERVICE_PREFIX), prefix=SERVICE_PREFIX)
+    cursor.execute(add_query_prefix(query_string))
+
+    # props in query order to map them to query result
+    props = [
+        'database', 'start_time', 'end_time',
+        'status', 'query', 'duration',
+        'returned_rows', 'returned_bytes'
+    ]
+
+    def format_res(row: List) -> dict:
+        res = dict(zip(props, row))
+        res['start_time'] = res['start_time'].timestamp()
+        if res.get('end_time'):
+            res['end_time'] = res['end_time'].timestamp()
+        return res
+
+    return list(map(lambda r: format_res(r), cursor.fetchall()))
+
+
+def close_wrapper(original, self):
+    with self.cursor() as cursor:
+        session_id, user_id, database = get_connection_info(cursor)
+        queries_info = get_queries_info(
+            cursor, user_id=user_id, database=database, session_id=session_id)
+        count_queries(queries=queries_info)
+    return original(self)

--- a/optscale_arcee/instrumentation/redshift_connector/wrapper.py
+++ b/optscale_arcee/instrumentation/redshift_connector/wrapper.py
@@ -1,23 +1,23 @@
 from typing import List
 
 from optscale_arcee.instrumentation.redshift_connector.stats import (
-    count_queries)
+    count_queries,
+)
 
-SERVICE_PREFIX = '/* requestor: Optscale */'
+SERVICE_PREFIX = "/* requestor: Optscale */"
 
 
 def add_query_prefix(query_text: str) -> str:
     # add specific prefix to mark our service queries
-    return f'{SERVICE_PREFIX} {query_text}'
+    return f"{SERVICE_PREFIX} {query_text}"
 
 
 def get_connection_info(cursor) -> tuple[int, int, str]:
     connection_info_query = """
-    select 
-      pg_backend_pid() as session_id, 
-      current_user_id as user_id, 
-      current_database() as database
-    """
+    select
+      pg_backend_pid() as session_id,
+      current_user_id as user_id,
+      current_database() as database"""
     cursor.execute(add_query_prefix(connection_info_query))
     result = cursor.fetchone()
     session_id, user_id, database = result
@@ -25,46 +25,55 @@ def get_connection_info(cursor) -> tuple[int, int, str]:
 
 
 def get_queries_info(
-        cursor, database: str, user_id: int, session_id: int
+    cursor, database: str, user_id: int, session_id: int
 ) -> List[dict]:
     # collect executed queries info in current session scope
     # excluding service queries
     query_string = """
-    select 
-      database_name, 
-      start_time, 
-      end_time, 
-      trim(status) as status,  
-      trim(query_text) as query, 
-      elapsed_time, 
-      returned_rows, 
-      returned_bytes 
-    from 
-      sys_query_history 
-    where 
-      session_id = {session_id} 
-      and database_name = '{database}' 
-      and user_id = {user_id} 
+    select
+      database_name,
+      start_time,
+      end_time,
+      trim(status) as status,
+      trim(query_text) as query,
+      elapsed_time,
+      returned_rows,
+      returned_bytes
+    from
+      sys_query_history
+    where
+      session_id = {session_id}
+      and database_name = '{database}'
+      and user_id = {user_id}
       and substring(query, 1, {prefix_len}) != '{prefix}'
-    order by 
+    order by
       start_time asc
     """.format(
-        database=database, session_id=session_id, user_id=user_id,
-        prefix_len=len(SERVICE_PREFIX), prefix=SERVICE_PREFIX)
+        database=database,
+        session_id=session_id,
+        user_id=user_id,
+        prefix_len=len(SERVICE_PREFIX),
+        prefix=SERVICE_PREFIX,
+    )
     cursor.execute(add_query_prefix(query_string))
 
     # props in query order to map them to query result
     props = [
-        'database', 'start_time', 'end_time',
-        'status', 'query', 'duration',
-        'returned_rows', 'returned_bytes'
+        "database",
+        "start_time",
+        "end_time",
+        "status",
+        "query",
+        "duration",
+        "returned_rows",
+        "returned_bytes",
     ]
 
     def format_res(row: List) -> dict:
         res = dict(zip(props, row))
-        res['start_time'] = res['start_time'].timestamp()
-        if res.get('end_time'):
-            res['end_time'] = res['end_time'].timestamp()
+        res["start_time"] = res["start_time"].timestamp()
+        if res.get("end_time"):
+            res["end_time"] = res["end_time"].timestamp()
         return res
 
     return list(map(lambda r: format_res(r), cursor.fetchall()))
@@ -74,6 +83,7 @@ def close_wrapper(original, self):
     with self.cursor() as cursor:
         session_id, user_id, database = get_connection_info(cursor)
         queries_info = get_queries_info(
-            cursor, user_id=user_id, database=database, session_id=session_id)
+            cursor, user_id=user_id, database=database, session_id=session_id
+        )
         count_queries(queries=queries_info)
     return original(self)

--- a/optscale_arcee/instrumentation/stats.py
+++ b/optscale_arcee/instrumentation/stats.py
@@ -7,9 +7,11 @@ def is_set(v) -> bool:
 
 
 def add(keys, left, right):
-    if type(left) != type(right):
-        raise TypeError(f'unsupported operand type(s) for +: '
-                        f'{type(left)} and {type(right)}')
+    if type(left) is not type(right):
+        raise TypeError(
+            f"unsupported operand type(s) for +: "
+            f"{type(left)} and {type(right)}"
+        )
     kwargs = {}
     for key in keys:
         # add dicts and stats objects
@@ -22,15 +24,17 @@ def add(keys, left, right):
         if is_set(left_value) ^ is_set(right_value):
             kwargs[key] = left_value or right_value
         elif is_set(left_value) and is_set(right_value):
-            if type(left_value) != type(right_value):
+            if type(left_value) is not type(right_value):
                 raise TypeError(
-                    f'unsupported operand type(s) for +: '
-                    f'{type(left_value)} and {type(right_value)}')
-            if hasattr(type(left_value), '__add__'):
+                    f"unsupported operand type(s) for +: "
+                    f"{type(left_value)} and {type(right_value)}"
+                )
+            if hasattr(type(left_value), "__add__"):
                 kwargs[key] = left_value + right_value
             elif isinstance(left_value, dict):
-                kwargs[key] = add({*left_value, *right_value},
-                                  left_value, right_value)
+                kwargs[key] = add(
+                    {*left_value, *right_value}, left_value, right_value
+                )
             elif isinstance(left_value, set):
                 kwargs[key] = left_value | right_value
     return type(left)(**kwargs)
@@ -39,11 +43,11 @@ def add(keys, left, right):
 class StatsMeta(type):
     def __new__(cls, name, bases, namespace, **kwds):
         # forcing to use slots on Stats classes
-        if '__slots__' not in namespace:
-            namespace['__slots__'] = ()
+        if "__slots__" not in namespace:
+            namespace["__slots__"] = ()
         for base in bases:
-            if hasattr(base, '__slots__'):
-                namespace['__slots__'] += base.__slots__
+            if hasattr(base, "__slots__"):
+                namespace["__slots__"] += base.__slots__
         return type.__new__(cls, name, bases, namespace, **kwds)
 
 
@@ -60,10 +64,10 @@ class Stats(metaclass=StatsMeta):
     def service(self) -> Optional[str]:
         return None
 
-    def __add__(self, other: 'Stats'):
+    def __add__(self, other: "Stats"):
         return add(self.__slots__, self, other)
 
-    def __radd__(self, other: 'Stats'):
+    def __radd__(self, other: "Stats"):
         return self.__add__(other)
 
     def to_dict(self) -> dict:

--- a/optscale_arcee/instrumentation/stats.py
+++ b/optscale_arcee/instrumentation/stats.py
@@ -1,0 +1,77 @@
+# flake8: noqa: E721
+from typing import Optional
+
+
+def is_set(v) -> bool:
+    return v is not None
+
+
+def add(keys, left, right):
+    if type(left) != type(right):
+        raise TypeError(f'unsupported operand type(s) for +: '
+                        f'{type(left)} and {type(right)}')
+    kwargs = {}
+    for key in keys:
+        # add dicts and stats objects
+        if isinstance(left, dict):
+            left_value = left.get(key)
+            right_value = right.get(key)
+        else:
+            left_value = getattr(left, key, None)
+            right_value = getattr(right, key, None)
+        if is_set(left_value) ^ is_set(right_value):
+            kwargs[key] = left_value or right_value
+        elif is_set(left_value) and is_set(right_value):
+            if type(left_value) != type(right_value):
+                raise TypeError(
+                    f'unsupported operand type(s) for +: '
+                    f'{type(left_value)} and {type(right_value)}')
+            if hasattr(type(left_value), '__add__'):
+                kwargs[key] = left_value + right_value
+            elif isinstance(left_value, dict):
+                kwargs[key] = add({*left_value, *right_value},
+                                  left_value, right_value)
+            elif isinstance(left_value, set):
+                kwargs[key] = left_value | right_value
+    return type(left)(**kwargs)
+
+
+class StatsMeta(type):
+    def __new__(cls, name, bases, namespace, **kwds):
+        # forcing to use slots on Stats classes
+        if '__slots__' not in namespace:
+            namespace['__slots__'] = ()
+        for base in bases:
+            if hasattr(base, '__slots__'):
+                namespace['__slots__'] += base.__slots__
+        return type.__new__(cls, name, bases, namespace, **kwds)
+
+
+class Stats(metaclass=StatsMeta):
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+    @property
+    def package(self) -> str:
+        raise NotImplementedError
+
+    @property
+    def service(self) -> Optional[str]:
+        return None
+
+    def __add__(self, other: 'Stats'):
+        return add(self.__slots__, self, other)
+
+    def __radd__(self, other: 'Stats'):
+        return self.__add__(other)
+
+    def to_dict(self) -> dict:
+        result = {}
+        for k in self.__slots__:
+            v = getattr(self, k, None)
+            if v is None:
+                # there is no use to dump unset or empty attrs. Omitting
+                continue
+            result[k] = v
+        return result

--- a/optscale_arcee/instrumentation/utils.py
+++ b/optscale_arcee/instrumentation/utils.py
@@ -1,0 +1,5 @@
+import os
+
+
+def get_package_name(path: str) -> str:
+    return os.path.basename(os.path.dirname(path)).lower()

--- a/optscale_arcee/sender/sender.py
+++ b/optscale_arcee/sender/sender.py
@@ -2,7 +2,8 @@ import aiohttp
 import threading
 
 from optscale_arcee.instrumentation.collector import (
-    Collector as InstrumentationCollector)
+    Collector as InstrumentationCollector,
+)
 from optscale_arcee.platform import CollectorFactory
 from optscale_arcee.module_collector.collector import (
     Collector as ImportsCollector,

--- a/optscale_arcee/sender/sender.py
+++ b/optscale_arcee/sender/sender.py
@@ -1,6 +1,8 @@
 import aiohttp
 import threading
 
+from optscale_arcee.instrumentation.collector import (
+    Collector as InstrumentationCollector)
 from optscale_arcee.platform import CollectorFactory
 from optscale_arcee.module_collector.collector import (
     Collector as ImportsCollector,
@@ -35,6 +37,10 @@ class Sender:
     @staticmethod
     async def _proc_data():
         return await HwCollector.collect_stats()
+
+    @staticmethod
+    async def _instrumentation_data():
+        return await InstrumentationCollector().get()
 
     @staticmethod
     async def _imports_data():
@@ -110,6 +116,8 @@ class Sender:
         data = dict()
         meta = await self.m()
         proc = await self._proc_data()
+        instrumentation = await self._instrumentation_data()
         data.update({"platform": meta.to_dict()})
         data.update({"proc_stats": proc})
+        data.update({"instrumentation_stats": instrumentation})
         return await self.send_post_request(uri, headers, data)

--- a/optscale_arcee/utils.py
+++ b/optscale_arcee/utils.py
@@ -1,0 +1,23 @@
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+from functools import partial
+
+
+def single(class_):
+    instances = {}
+
+    def get_instance(*args, **kwargs):
+        if class_ not in instances:
+            instances[class_] = class_(*args, **kwargs)
+        return instances[class_]
+
+    return get_instance
+
+
+async def run_async(func, *args, loop=None, executor=None, **kwargs):
+    if loop is None:
+        loop = asyncio.get_event_loop()
+    if executor is None:
+        executor = ThreadPoolExecutor(max_workers=10)
+    pfunc = partial(func, *args, **kwargs)
+    return await loop.run_in_executor(executor, pfunc)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 # setup.cfg
 [metadata]
 name = optscale_arcee
-version = 0.1.36
+version = 0.2.1
 author = Hystax
 description = ML profiling tool for OptScale
 long_description = file: README.md
@@ -18,6 +18,7 @@ install_requires =
     aiofiles==22.1.0
     GPUtil==1.4.0
     psutil==5.9.2
+    gorilla==0.4.0
 packages = find:
 package_dir =
     =.

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ commands =
     py.test tests {posargs}
 
 [flake8]
-exclude = .tox,*.egg,build,data, demo*
+exclude = .tox,*.egg,build,data
 max-line-length = 79
 select = E,W,F
 ignore = W504

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ commands =
     py.test tests {posargs}
 
 [flake8]
-exclude = .tox,*.egg,build,data
+exclude = .tox,*.egg,build,data, demo*
 max-line-length = 79
 select = E,W,F
+ignore = W504


### PR DESCRIPTION
Basic changese to deliver external packages instrumentation. When enabled arcee collects package usage stats and sends them on hb to OptScale for further analysis.

Currently supports boto3.s3 and boto3.ec2.
Note: currently there is no compatibility with previous boto3
      versions. It will be delivered later.

Instrumentation can be enabled by several ways:
- import arcee and call instrument() to enable instrumentation for all awailable packages
- import instrumentation of target package and call instrument() to enable certain instrumentation
- import instrumentation of target service (for example s3) and call instrument() to enable certain service instrumentation

Enabled instrumentation affects only newly created packages related objects (clients, objects, resources and so on)