### PR TITLE
OS-7355. Changed model/application to task

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,26 +18,26 @@ import optscale_arcee as arcee
 
 ```sh
 # init arcee using context manager syntax
-with arcee.init('token', 'model_key'):
+with arcee.init('token', 'task_key'):
     # some code
 ```
 
 To use custom endpoint and enable\disable ssl checks (supports using self-signed ssl certificates):
 ```sh
-with arcee.init('token', 'model_key', endpoint_url='https://my.custom.endpoint:443/arcee/v2', ssl=False):
+with arcee.init('token', 'task_key', endpoint_url='https://my.custom.endpoint:443/arcee/v2', ssl=False):
     # some code
 ```
 
 Alternatively arcee can be initialized via function call. However manual finish is required:
 ```sh
-arcee.init('token', 'model_key')
+arcee.init('token', 'task_key')
 # some code
 arcee.finish()
 ```
 
 Or in error case:
 ```sh
-arcee.init('token', 'model_key')
+arcee.init('token', 'task_key')
 # some code
 arcee.error()
 ```

--- a/examples/linear_regression.py
+++ b/examples/linear_regression.py
@@ -7,7 +7,7 @@ import optscale_arcee as arcee
 
 
 # init arcee
-arcee.init(token="test", model_key="linear_regression")
+arcee.init(token="test", task_key="linear_regression")
 
 arcee.tag("project", "regression")
 

--- a/examples/torchvision_demo.py
+++ b/examples/torchvision_demo.py
@@ -74,7 +74,7 @@ def test(dataloader, model, loss_fn):
 
 if __name__ == "__main__":
     # init arcee
-    with arcee.init(token="test", model_key="torchvision"):
+    with arcee.init(token="test", task_key="torchvision"):
         arcee.tag("project", "torchvision demo")
 
         # Download training data

--- a/optscale_arcee/arcee.py
+++ b/optscale_arcee/arcee.py
@@ -1,4 +1,5 @@
 import asyncio
+import warnings
 import time
 import threading
 
@@ -36,11 +37,11 @@ class Job(threading.Thread):
 @single
 class Arcee:
     def __init__(
-        self, token=None, model_key=None, endpoint_url=None, ssl=True
+        self, token=None, task_key=None, endpoint_url=None, ssl=True
     ):
         self.shutdown_flag = threading.Event()
         self.token = token
-        self.model_key = model_key
+        self.task_key = task_key
         self.sender = Sender(endpoint_url, ssl, self.shutdown_flag)
         self.hb = None
         self._run = None
@@ -103,14 +104,23 @@ class Arcee:
 
 
 def init(
-    token, model_key, run_name=None, endpoint_url=None, ssl=True, period=1
+    token, task_key=None, run_name=None, endpoint_url=None, ssl=True, period=1,
+        model_key=None
 ):
+    if model_key:
+        warnings.warn(
+            "`model_key` parameter is deprecated and will be removed in the "
+            "future releases, consider using `task_key` instead",
+            UserWarning
+        )
+    if not task_key or model_key:
+        raise TypeError('`task_key` is not provided')
     acquire_console()
-    arcee = Arcee(token, model_key, endpoint_url, ssl)
+    arcee = Arcee(token, task_key or model_key, endpoint_url, ssl)
     name = (
         run_name if run_name is not None else NameGenerator.get_random_name()
     )
-    run_id = asyncio.run(arcee.sender.get_run_id(model_key, token, name))["id"]
+    run_id = asyncio.run(arcee.sender.get_run_id(task_key, token, name))["id"]
     arcee.run = run_id
     arcee.name = name
     arcee.hb = Job(
@@ -122,7 +132,7 @@ def init(
     asyncio.run(
         arcee.sender.send_stats(
             arcee.token,
-            {"project": arcee.model_key, "run": arcee.run, "data": {}},
+            {"project": arcee.task_key, "run": arcee.run, "data": {}},
         )
     )
     return arcee
@@ -163,7 +173,7 @@ def dataset(path):
     if arcee.dataset is None:
         arcee.dataset = path
         asyncio.run(arcee.sender.register_dataset(
-            arcee.run, arcee.name, arcee.model_key, path, arcee.token))
+            arcee.run, arcee.name, arcee.task_key, path, arcee.token))
 
 
 def finish():
@@ -222,6 +232,6 @@ def send(data):
     asyncio.run(
         arcee.sender.send_stats(
             arcee.token,
-            {"project": arcee.model_key, "run": arcee.run, "data": data},
+            {"project": arcee.task_key, "run": arcee.run, "data": data},
         )
     )

--- a/optscale_arcee/sender/sender.py
+++ b/optscale_arcee/sender/sender.py
@@ -78,8 +78,8 @@ class Sender:
                 return await response.json()
 
     @check_shutdown_flag_set
-    async def get_run_id(self, model_key, token, run_name):
-        uri = "%s/applications/%s/run" % (self.endpoint_url, model_key)
+    async def get_run_id(self, task_key, token, run_name):
+        uri = "%s/tasks/%s/run" % (self.endpoint_url, task_key)
         headers = {"x-api-key": token, "Content-Type": "application/json"}
         data = {
             "imports": await self._imports_data(),
@@ -136,7 +136,7 @@ class Sender:
         return await self.send_post_request(uri, headers, data)
 
     @check_shutdown_flag_set
-    async def register_dataset(self, run_id, run_name, model_key, path, token):
+    async def register_dataset(self, run_id, run_name, task_key, path, token):
         uri = f"{self.endpoint_url}/run/{run_id}/dataset_register"
         headers = {"x-api-key": token, "Content-Type": "application/json"}
 
@@ -144,7 +144,7 @@ class Sender:
             "path": path,
             "name": f"Dataset {int(datetime.utcnow().timestamp())}",
             "description": f"Discovered in training "
-                           f"{model_key} - {run_name}({run_id})"
+                           f"{task_key} - {run_name}({run_id})"
         }
         await self.send_post_request(uri, headers, data)
 


### PR DESCRIPTION
## Description

Renamed model/application to task. `model_key` parameter becomes deprecated.

## Related issue number

OS-7355

## Checklist

* [ ] The pull request title is a good summary of the changes
* [ ] Unit tests for the changes exist
* [ ] New and existing unit tests pass locally